### PR TITLE
Fix shift name localization bug

### DIFF
--- a/src/initialisation.mjs
+++ b/src/initialisation.mjs
@@ -13,7 +13,6 @@ Hooks.once('init', () => {
     console.group('JD ETime | init')
 
     registerKeybindings()
-    registerSettings()
 
     const uiPanel = new UIPanel()
     uiPanel.init()
@@ -27,6 +26,8 @@ Hooks.once('init', () => {
 
 Hooks.once('ready', async () => {
     console.group('JD ETime | ready')
+
+    registerSettings()
 
     const timekeeper = new Timekeeper()
     timekeeper.init()


### PR DESCRIPTION
Moving module settings registration from init hook to ready hook so string localization can be used to set initial values. Resolves #133