### PR TITLE
Renamed the GM setting controlling player visibility of the exact time for improved clarity of use

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -46,8 +46,6 @@
     "JDTIMEKEEPING.SetTime.title": "Set the Time",
     "JDTIMEKEEPING.SetTime.label": "Time",
     "JDTIMEKEEPING.SetTime.hotkey": "Open the Set Time dialog",
-    "JDTIMEKEEPING.Settings.ShowTimeOfDay.name": "Show the current time of day on the UI panel to Players",
-    "JDTIMEKEEPING.Settings.ShowTimeOfDay.hint": "The time is always shown to the GM",
     "JDTIMEKEEPING.Settings.ShowDragonbaneTime.name": "Show the fuzzy Dragonbane time in stretches and shifts",
     "JDTIMEKEEPING.Settings.ShowDragonbaneTime.hint": "If selected, this will be shown to players and the GM",
     "JDTIMEKEEPING.Settings.ShowRadialClock.name": "Show the circular Dragonbane clocks",
@@ -75,5 +73,7 @@
     "JDTIMEKEEPING.UI.smallInc": "Small Increment",
     "JDTIMEKEEPING.UI.largeInc": "Large Increment",
     "JDTIMEKEEPING.UI.set": "Set the Time",
-    "JDTIMEKEEPING.Time.Stretch": "Stretch"
+    "JDTIMEKEEPING.Time.Stretch": "Stretch",
+    "JDTIMEKEEPING.Settings.ShowPlayersExactTime.name": "Show players the exact time",
+    "JDTIMEKEEPING.Settings.ShowPlayersExactTime.hint": "The exact time is always shown to the GM and Assistant GM"
 }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -46,8 +46,6 @@
     "JDTIMEKEEPING.SetTime.title": "Réglage de l'heure",
     "JDTIMEKEEPING.SetTime.label": "Heure",
     "JDTIMEKEEPING.SetTime.hotkey": "Ouvre la boîte de dialogue Régler l'heure",
-    "JDTIMEKEEPING.Settings.ShowTimeOfDay.name": "Afficher l'heure actuelle de la journée aux Joueurs",
-    "JDTIMEKEEPING.Settings.ShowTimeOfDay.hint": " L'heure est toujours indiquée pour le MJ",
     "JDTIMEKEEPING.Settings.ShowDragonbaneTime.name": "Afficher l'heure approximative dans Dragonbane par tranche de Périodes et d'Intervalles",
     "JDTIMEKEEPING.Settings.ShowDragonbaneTime.hint": "Si sélectionné, cela sera visible pour les joueurs et le MJ",
     "JDTIMEKEEPING.Settings.ShowRadialClock.name": "Afficher les horloges rondes de Dragonbane",
@@ -75,5 +73,7 @@
     "JDTIMEKEEPING.UI.smallInc": "Faible Augmentation",
     "JDTIMEKEEPING.UI.largeInc": "Forte Augmentation",
     "JDTIMEKEEPING.UI.set": "Régler l'heure",
-    "JDTIMEKEEPING.Time.Stretch": "Période"
+    "JDTIMEKEEPING.Time.Stretch": "Période",
+    "JDTIMEKEEPING.Settings.ShowPlayersExactTime.name": "Show players the exact time",
+    "JDTIMEKEEPING.Settings.ShowPlayersExactTime.hint": "The exact time is always shown to the GM and Assistant GM"
 }

--- a/src/helpers.mjs
+++ b/src/helpers.mjs
@@ -121,9 +121,9 @@ export class Helpers {
      * 
      * @returns {boolean} `true` if the exact time can be shown, `false` otherwise
      */
-    static get showTimeOfDay () {
+    static get showExactTime () {
         // The time of day string is always shown for a GM, and conditionally for
         // players based on the module setting
-        return game.user.isGM || game.settings.get(MODULE_ID, SETTINGS.SHOW_TIME_OF_DAY)
+        return game.user.isGM || game.settings.get(MODULE_ID, SETTINGS.SHOW_PLAYERS_EXACT_TIME)
     }
 }

--- a/src/settings.mjs
+++ b/src/settings.mjs
@@ -18,7 +18,7 @@ export const SETTINGS = {
     UI_RADIAL_CLOCK_COLOR: 'uiRadialClockColor',
     SHOW_RADIAL_CLOCK: 'showRadialClock',
     SHOW_DRAGONBANE_TIME: 'showDragonbaneTime',
-    SHOW_TIME_OF_DAY: 'showTimeOfDay',
+    SHOW_PLAYERS_EXACT_TIME: 'showPlayersExactTime',
     UI_TEXT_COLOR: 'uiTextColor',
     RADIAL_CLOCK_COLOR: 'radialClockColor',
 }
@@ -29,9 +29,9 @@ export function registerSettings () {
     registerDaylightCycleSettings()
     registerShiftSettings()
 
-    game.settings.register(MODULE_ID, SETTINGS.SHOW_TIME_OF_DAY, {
-        name: 'JDTIMEKEEPING.Settings.ShowTimeOfDay.name',
-        hint: 'JDTIMEKEEPING.Settings.ShowTimeOfDay.hint',
+    game.settings.register(MODULE_ID, SETTINGS.SHOW_PLAYERS_EXACT_TIME, {
+        name: 'JDTIMEKEEPING.Settings.ShowPlayersExactTime.name',
+        hint: 'JDTIMEKEEPING.Settings.ShowPlayersExactTime.hint',
         scope: 'world',
         config: true,
         type: Boolean,

--- a/src/timekeeper.mjs
+++ b/src/timekeeper.mjs
@@ -80,7 +80,7 @@ export class Timekeeper {
      * @returns {time} the current time
      */
     getTime () {
-        if (!Helpers.showTimeOfDay) {
+        if (!Helpers.showExactTime) {
             ui.notifications.warn(game.i18n.localize('JDTIMEKEEPING.NoPermission'))
             return false
         }
@@ -95,7 +95,7 @@ export class Timekeeper {
      * @returns {string} the current time as a formatted string suitable for display
      */
     toTimeString (includeDay = false) {
-        if (!Helpers.showTimeOfDay) {
+        if (!Helpers.showExactTime) {
             ui.notifications.warn(game.i18n.localize('JDTIMEKEEPING.NoPermission'))
             return false
         }
@@ -111,7 +111,7 @@ export class Timekeeper {
      * @public
      */
     tellTime () {
-        if (!Helpers.showTimeOfDay) {
+        if (!Helpers.showExactTime) {
             ui.notifications.warn(game.i18n.localize('JDTIMEKEEPING.NoPermission'))
             return false
         }


### PR DESCRIPTION
Renamed show time of day to showPlayersExactTime along with corresponding changes to the settings and localised strings. It's a clearer indication of intent and use.

Fixes #127