### PR TITLE
Fixed issue where UI appeared in the wrong location when Foundry A/V Chat was enabled

### DIFF
--- a/src/initialisation.mjs
+++ b/src/initialisation.mjs
@@ -13,10 +13,7 @@ Hooks.once('init', () => {
     console.group('JD ETime | init')
 
     registerKeybindings()
-
-    const uiPanel = new UIPanel()
-    uiPanel.init()
-    game.modules.get(MODULE_ID).uiPanel = uiPanel
+    UIPanel.registerKeybindings()
 
     console.groupEnd()
 })
@@ -42,5 +39,8 @@ Hooks.once('ready', async () => {
 })
 
 Hooks.on('canvasReady', () => {
-    game.modules.get(MODULE_ID).uiPanel.render(true)
+    const uiPanel = new UIPanel()
+    uiPanel.ready()
+    uiPanel.render(true)
+    game.modules.get(MODULE_ID).uiPanel = uiPanel
 })

--- a/src/uipanel.mjs
+++ b/src/uipanel.mjs
@@ -73,7 +73,6 @@ export class UIPanel extends HandlebarsApplicationMixin(ApplicationV2) {
          * This creates a DOM element in the ui-left interface div,
          * in between the canvas controls and the players panel.
          * Technique from Global Progress Clocks.
-         * Shame it doesn't appear to work with ApplicationV2, since it put the UI exactly where I wanted it
          * */
         const top = document.querySelector(target)
         if (top) {

--- a/src/uipanel.mjs
+++ b/src/uipanel.mjs
@@ -33,15 +33,13 @@ export class UIPanel extends HandlebarsApplicationMixin(ApplicationV2) {
     #time = { minutes: 0, hours: 0, days: 0 }
     refresh = foundry.utils.debounce(this.render, 100)
 
-    init () {
+    ready () {
         Hooks.on(Timekeeper.TIME_CHANGE_HOOK, this.timeChangeHandler.bind(this))
         game.socket.on(`module.${MODULE_ID}`, time => {
             this.#time = time
             this.render(true)
         })
         if (!UIPanel.DEFAULT_OPTIONS.window.frame) this.#insertAppElement('#players')
-
-        UIPanel.registerKeybindings()
     }
 
     static registerKeybindings () {

--- a/styles/easy-timekeeping.css
+++ b/styles/easy-timekeeping.css
@@ -224,20 +224,13 @@
  * Styles grafted from Global Progress Clocks are below here.
  * They control the circular clocks used to display Dragonbane time.
  */
-/* .etk-clock-panel {
-  gap: 5px;
-  right: 0;
-
-  .etk-clock-list {
-    align-items: center;
-  }
-} */
 
 .etk-clock-panel .etk-clock-entry {
   display: flex;
+  flex-wrap: nowrap;
   flex-direction: row;
   align-items: center;
-  height: 44px;
+  height: 44px; 
   border-radius: 5px 22px 22px 5px;
   border-right: none;
 


### PR DESCRIPTION
Note that due to another issue, a manual application refresh is sometimes required when the A/V Chat dock location is changed. I have opened #178 to address this, but until that is fixed, a manual refresh is the workaround.