### PR TITLE
Added customisable week name

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -75,7 +75,7 @@
     "JDTIMEKEEPING.Time.Stretch": "Stretch",
     "JDTIMEKEEPING.Settings.ShowPlayersExactTime.name": "Show Players the Exact Time",
     "JDTIMEKEEPING.Settings.ShowPlayersExactTime.hint": "The exact time is always shown to the GM and Assistant GM",
-    "JDTIMEKEEPING.Time.DayAndWeek": "{day}, week {week}",
+    "JDTIMEKEEPING.Time.DayAndWeek": "{day}, {weekName} {week}",
     "JDTIMEKEEPING.Settings.UIFadeOpacity.name": "UI Idle Transparency",
     "JDTIMEKEEPING.Settings.UIFadeOpacity.hint": "Controls the UI transparency when not in use. 0 is fully hidden, and 1 is fully visible.",
     "JDTIMEKEEPING.Settings.RadialClockBGColor.name": "Circular Clock Background Color",
@@ -90,12 +90,13 @@
     "JDTIMEKEEPING.Friday": "Friday",
     "JDTIMEKEEPING.Saturday": "Saturday",
     "JDTIMEKEEPING.Sunday": "Sunday",
+    "JDTIMEKEEPING.WeekName": "Week",
     
     "JDTIMEKEEPING.Settings.WeekdayConfig.name": "Configure the Days of the Week",
     "JDTIMEKEEPING.Settings.WeekdayConfig.label": "Rename Weekdays",
     "JDTIMEKEEPING.Settings.WeekdayConfig.hint": "",
 
-    "JDTIMEKEEPING.longTimeFormat": "{time}, {dayName} week {weekNumber}",
+    "JDTIMEKEEPING.longTimeFormat": "{time}, {dayName} {weekName} {weekNumber}",
 
     "JDTIMEKEEPING.Settings.UIButtonColor.name": "Time Step Button Color",
     "JDTIMEKEEPING.Settings.UIButtonColor.hint": "",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -75,7 +75,7 @@
     "JDTIMEKEEPING.Time.Stretch": "Période",
     "JDTIMEKEEPING.Settings.ShowPlayersExactTime.name": "Afficher l'heure exacte aux joueurs",
     "JDTIMEKEEPING.Settings.ShowPlayersExactTime.hint": "L'heure exacte est toujours indiquée au MJ et au MJ adjoint.",
-    "JDTIMEKEEPING.Time.DayAndWeek": "{day}, Semaine: {week}",
+    "JDTIMEKEEPING.Time.DayAndWeek": "{day}, {weekName}: {week}",
     "JDTIMEKEEPING.Settings.UIFadeOpacity.name": " Transparence de l'interface en mode veille",
     "JDTIMEKEEPING.Settings.UIFadeOpacity.hint": "Contrôle la transparence de l'interface lorsqu'elle n'est pas utilisée. 0 est totalement caché et 1 est totalement visible.",
     "JDTIMEKEEPING.Settings.RadialClockBGColor.name": "Couleur de fond de l'horloge ronde",
@@ -90,12 +90,13 @@
     "JDTIMEKEEPING.Friday": "Vendredi",
     "JDTIMEKEEPING.Saturday": "Samedi",
     "JDTIMEKEEPING.Sunday": "Dimanche",
+    "JDTIMEKEEPING.WeekName": "Semaine",
     
     "JDTIMEKEEPING.Settings.WeekdayConfig.name": "Configurer les jours de la semaine",
     "JDTIMEKEEPING.Settings.WeekdayConfig.label": "Renommer les jours de la semaine",
     "JDTIMEKEEPING.Settings.WeekdayConfig.hint": "",
 
-    "JDTIMEKEEPING.longTimeFormat": "{dayName}, {time} | Semaine: {weekNumber}",
+    "JDTIMEKEEPING.longTimeFormat": "{dayName}, {time} | {weekName}: {weekNumber}",
 
     "JDTIMEKEEPING.Settings.UIButtonColor.name": "Couleur des boutons",
     "JDTIMEKEEPING.Settings.UIButtonColor.hint": "",

--- a/src/helpers.mjs
+++ b/src/helpers.mjs
@@ -24,6 +24,7 @@ export class Helpers {
             return game.i18n.format('JDTIMEKEEPING.longTimeFormat', {
                 time: timeOfDay,
                 dayName: time.day.name,
+                weekName: this.weekName,
                 weekNumber: time.weekNumber,
             })
         } else {
@@ -144,5 +145,13 @@ export class Helpers {
     static getWeekdayName (dayIndex) {
         const weekdays = game.settings.get(MODULE_ID, SETTINGS.WEEKDAY_SETTINGS)
         return Object.values(weekdays)[dayIndex]
+    }
+
+    /**
+     * Returns the current world setting for the word used for the name of a week
+     */
+    static get weekName () {
+        const weekSettings = game.settings.get(MODULE_ID, SETTINGS.WEEKDAY_SETTINGS)
+        return weekSettings.weekname
     }
 }

--- a/src/initialisation.mjs
+++ b/src/initialisation.mjs
@@ -35,6 +35,15 @@ Hooks.once('ready', async () => {
     game.modules.get(MODULE_ID).timeChangeHookName = Timekeeper.TIME_CHANGE_HOOK
     game.modules.get(MODULE_ID).constants = Constants
 
+    // I don't need this for now
+    // Handlebars.registerHelper('ifEquals', function (arg1, arg2, options) {
+    //     return arg1 == arg2 ? options.fn(this) : options.inverse(this)
+    // })
+    // {{#ifEquals sampleString "This is a string"}}
+    // Your HTML here
+    // {{else}}
+    // {{/ifEquals}}
+
     console.groupEnd()
 })
 

--- a/src/uipanel.mjs
+++ b/src/uipanel.mjs
@@ -137,6 +137,7 @@ export class UIPanel extends HandlebarsApplicationMixin(ApplicationV2) {
                 max: 7,
                 name: game.i18n.format('JDTIMEKEEPING.Time.DayAndWeek', {
                     day: time.day.name,
+                    weekName: Helpers.weekName,
                     week: time.weekNumber,
                 }),
                 color: UIPanel.#clockFGColor,

--- a/src/weekdaysettings.mjs
+++ b/src/weekdaysettings.mjs
@@ -1,7 +1,7 @@
 import { Helpers } from './helpers.mjs'
 import { MODULE_ID, SETTINGS } from './settings.mjs'
 
-const weekdays = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday']
+const weekdays = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday', 'WeekName']
 
 export function registerWeekdaySettings () {
     // The settings menu
@@ -50,6 +50,13 @@ class WeekdaySettings extends FormApplication {
                 value: initialValues[v.toLowerCase()],
             }
         })
+
+        // data.weekday = {
+        //     id: 'weekName',
+        //     label: game.i18n.localize('JDTIMEKEEPING.WeekName'),
+        //     value: initialValues['weekName'],
+        // }
+
         return data
     }
 


### PR DESCRIPTION
Individual weeks don't have names. But the word used for "week" can be customised in the same settings menu where the names of the days are customised.