### PR TITLE
Fixing UI issues when Foundry Audio/Video is enabled. The module detects this and automatically switches to the floating panel.

### DIFF
--- a/src/timekeeper.mjs
+++ b/src/timekeeper.mjs
@@ -269,7 +269,7 @@ export class Timekeeper {
 
 /**
  * Day data
- * 
+ *
  * @public
  * @typedef {Object} dayData
  * @property {number} index 1-based number of the day of the week, starting with Monday. Each week is fixed at 7 days.
@@ -286,7 +286,7 @@ export class Timekeeper {
 
 /**
  * Game turn time. This is used by the graphical clocks, and returned from API calls.
- * 
+ *
  * @public
  * @typedef {Object} gameTurnTime
  * @property {number} totalGameTurns total number of elapsed game turns

--- a/src/uipanel.mjs
+++ b/src/uipanel.mjs
@@ -155,6 +155,9 @@ export class UIPanel extends HandlebarsApplicationMixin(ApplicationV2) {
     static checkForAVPanel () {
         if (UIPanel.avEnabled && !UIPanel.floatingPanel) {
             // This is a pathological layout situation: the AV dock disrupts the docked UI
+            // todo: I could only do the check for the left & right dock settings, but it's safer to use all.
+            // Also, this bug was actually fixed in PR #254, but I needed a commit to get a PR for this bug fix
+            // so the release notes workflow will pick this up. Weird.
             ui.notifications.warn(game.i18n.localize('JDTIMEKEEPING.AVDockWarning'))
             game.settings.set(MODULE_ID, SETTINGS.FLOATING_UI_PANEL, true)
         }


### PR DESCRIPTION
Bug was actually fixed in #254 