### PR TITLE
Fixed bug with initial floating UI position when loading a world with no active scene.

### DIFF
--- a/src/uipanel.mjs
+++ b/src/uipanel.mjs
@@ -49,8 +49,8 @@ export class UIPanel extends HandlebarsApplicationMixin(ApplicationV2) {
         // if position if out of bounds for current client view, reset to a safe location in the top left
         if (position) {
             if (
-                position.top > game.canvas.screenDimensions[1] ||
-                position.left > game.canvas.screenDimensions[0]
+                position.top > window.visualViewport.height || 
+                position.left > window.visualViewport.width
             ) {
                 position.top = 100
                 position.left = 150


### PR DESCRIPTION
changing initial floating window position check to compare to viewport rather than game canvas.

fixes #259