### PR TITLE
Fixed bug where the toggle UI hotkey sometimes had to be pressed twice to show the UI after it was closed manually.

### DIFF
--- a/src/uipanel.mjs
+++ b/src/uipanel.mjs
@@ -225,6 +225,7 @@ export class UIPanel extends HandlebarsApplicationMixin(ApplicationV2) {
     }
 
     _onClose () {
+        UIPanel.#hidden = true
         game.settings.set(MODULE_ID, SETTINGS.FLOATING_UI_PANEL_POSITION, this.position)
     }
 


### PR DESCRIPTION
Setting hidden flag when UI is closed manually, so that the toggle hotkey handler doesn't think the UI is still open

#261