### PR TITLE
Refactored code to use `Constants.daysPerWeek` instead of hard-coded 7-day weeks.

### DIFF
--- a/src/helpers.mjs
+++ b/src/helpers.mjs
@@ -76,10 +76,9 @@ export class Helpers {
         gameTurnData.turns = remainingGameTurns % Constants.turnsPerShift
 
         gameTurnData.shiftName = Helpers.getDragonbaneShiftName(gameTurnData.shifts)
-        // todo: Code Smell! should use Constants.daysPerWeek
-        gameTurnData.day = { index: (gameTurnData.days % 7) + 1 } // 1-based day index for UI
+        gameTurnData.day = { index: (gameTurnData.days % Constants.daysPerWeek) + 1 } // 1-based day index for UI
         gameTurnData.day.name = Helpers.getWeekdayName(gameTurnData.day.index - 1) // lookup by 0-based index
-        gameTurnData.weekNumber = Math.floor(gameTurnData.days / 7) + 1 // 1-based week number
+        gameTurnData.weekNumber = Math.floor(gameTurnData.days / Constants.daysPerWeek) + 1 // 1-based week number
 
         return gameTurnData
     }

--- a/src/timekeeper.mjs
+++ b/src/timekeeper.mjs
@@ -212,11 +212,9 @@ export class Timekeeper {
         time.days = Math.floor(totalMinutes / Constants.minutesPerDay)
         time.hours = Math.floor((totalMinutes % Constants.minutesPerDay) / 60)
         time.minutes = (totalMinutes % Constants.minutesPerDay) % 60
-        // todo: Code Smell! should use Constants.daysPerWeek
-        time.day = { index: (time.days % 7) + 1 } // 1-based day index for UI
+        time.day = { index: (time.days % Constants.daysPerWeek) + 1 } // 1-based day index for UI
         time.day.name = Helpers.getWeekdayName(time.day.index - 1) // lookup by 0-based index
-        // todo: Code Smell! should use Constants.daysPerWeek
-        time.weekNumber = Math.floor(time.days / 7) + 1 // 1-based week number
+        time.weekNumber = Math.floor(time.days / Constants.daysPerWeek) + 1 // 1-based week number
 
         return time
     }

--- a/src/uipanel.mjs
+++ b/src/uipanel.mjs
@@ -198,8 +198,7 @@ export class UIPanel extends HandlebarsApplicationMixin(ApplicationV2) {
                  */
                 id: 'etk-days',
                 value: time.day.index,
-                // todo: Code Smell! should use Constants.daysPerWeek
-                max: 7,
+                max: Constants.daysPerWeek,
                 name: game.i18n.format('JDTIMEKEEPING.Time.DayAndWeek', {
                     day: time.day.name,
                     weekName: Helpers.weekName,


### PR DESCRIPTION
Fixes issue #282
This helps pave the way for #276 and more flexible and configurable length weeks as a module option.