### PR TITLE
Fixed inconsistent type capitalization in API docs

### DIFF
--- a/documentation/timekeeper.md
+++ b/documentation/timekeeper.md
@@ -150,16 +150,16 @@ Constants used in time calculations.
 
 ### Properties
 
-*   `secondsPerDay` **[Number][21]** The number of seconds in a day.
-*   `minutesPerDay` **[Number][21]** The number of minutes in a day.
-*   `hoursPerDay` **[Number][21]** The number of hours in a day.
-*   `shiftsPerDay` **[Number][21]** The number of shifts in a day.
-*   `minutesPerShift` **[Number][21]** The number of minutes in a shift.
-*   `hoursPerShift` **[Number][21]** The number of hours in a shift.
-*   `daysPerWeek` **[Number][21]** The number of days in a week.
-*   `minutesPerTurn` **[Number][21]** The number of minutes in a game turn. Will vary by current module settings.
-*   `turnsPerShift` **[Number][21]** The number of game turns per shift. Will vary by current module settings.
-*   `turnsPerDay` **[Number][21]** The number of game turns per day. Will vary by current module settings.
+*   `secondsPerDay` **[number][21]** The number of seconds in a day.
+*   `minutesPerDay` **[number][21]** The number of minutes in a day.
+*   `hoursPerDay` **[number][21]** The number of hours in a day.
+*   `shiftsPerDay` **[number][21]** The number of shifts in a day.
+*   `minutesPerShift` **[number][21]** The number of minutes in a shift.
+*   `hoursPerShift` **[number][21]** The number of hours in a shift.
+*   `daysPerWeek` **[number][21]** The number of days in a week.
+*   `minutesPerTurn` **[number][21]** The number of minutes in a game turn. Will vary by current module settings.
+*   `turnsPerShift` **[number][21]** The number of game turns per shift. Will vary by current module settings.
+*   `turnsPerDay` **[number][21]** The number of game turns per day. Will vary by current module settings.
 
 [1]: #timekeeper
 

--- a/src/constants.mjs
+++ b/src/constants.mjs
@@ -5,16 +5,16 @@ import { MODULE_ID, SETTINGS } from './settings.mjs'
 /**
  * Constants used in time calculations.
  * 
- * @property {Number} secondsPerDay The number of seconds in a day.
- * @property {Number} minutesPerDay The number of minutes in a day.
- * @property {Number} hoursPerDay The number of hours in a day.
- * @property {Number} shiftsPerDay The number of shifts in a day.
- * @property {Number} minutesPerShift The number of minutes in a shift.
- * @property {Number} hoursPerShift The number of hours in a shift.
- * @property {Number} daysPerWeek The number of days in a week.
- * @property {Number} minutesPerTurn The number of minutes in a game turn. Will vary by current module settings.
- * @property {Number} turnsPerShift The number of game turns per shift. Will vary by current module settings.
- * @property {Number} turnsPerDay The number of game turns per day. Will vary by current module settings.
+ * @property {number} secondsPerDay The number of seconds in a day.
+ * @property {number} minutesPerDay The number of minutes in a day.
+ * @property {number} hoursPerDay The number of hours in a day.
+ * @property {number} shiftsPerDay The number of shifts in a day.
+ * @property {number} minutesPerShift The number of minutes in a shift.
+ * @property {number} hoursPerShift The number of hours in a shift.
+ * @property {number} daysPerWeek The number of days in a week.
+ * @property {number} minutesPerTurn The number of minutes in a game turn. Will vary by current module settings.
+ * @property {number} turnsPerShift The number of game turns per shift. Will vary by current module settings.
+ * @property {number} turnsPerDay The number of game turns per day. Will vary by current module settings.
  * 
  * @public
  */


### PR DESCRIPTION
Replaced `Number` with `number` in `Constants` JSDoc strings.