### PR TITLE
Updated release workflow to `devops-actions/variable-substitution` since the old Action has been deprecated.

### DIFF
--- a/.github/workflows/release-creation.yml
+++ b/.github/workflows/release-creation.yml
@@ -46,7 +46,9 @@ jobs:
 
       - name: Populate Versioned keys in Manifest
         id: sub_manifest_link_version
-        uses: microsoft/variable-substitution@v1
+        # Updated from microsoft/variable-substitution@v1 since that Action is deprecated. 
+        # See #313 and https://github.com/DC23/jd-easytimekeeping/wiki/Dev-Ops#variable-substitution
+        uses: devops-actions/variable-substitution@v1.2
         with:
           files: 'module.json'
         env:


### PR DESCRIPTION
#313